### PR TITLE
Play control to details

### DIFF
--- a/app/src/main/java/com/mccarty/ritmo/domain/tracks/TrackSelectAction.kt
+++ b/app/src/main/java/com/mccarty/ritmo/domain/tracks/TrackSelectAction.kt
@@ -6,8 +6,8 @@ import com.mccarty.ritmo.viewmodel.PlaylistNames
 sealed class TrackSelectAction {
     data class TrackSelect(
         val index: Int,
-        val uri: String,
-        val duration: Long,
+        val uri: String? = null,
+        val duration: Long? = 0L,
         val tracks: List<MainItem>,
         val playlistName: PlaylistNames,
     ) : TrackSelectAction()

--- a/app/src/main/java/com/mccarty/ritmo/ui/MainComposeScreen.kt
+++ b/app/src/main/java/com/mccarty/ritmo/ui/MainComposeScreen.kt
@@ -89,6 +89,9 @@ fun MainComposeScreen(
                 onPlayerControlAction = {
                     onPlayerControlAction(it)
                 },
+                onNavigateToDetails = {
+                    navActions.navigateToTrackDetails(it)
+                },
             )
         }
     }

--- a/app/src/main/java/com/mccarty/ritmo/ui/components.kt
+++ b/app/src/main/java/com/mccarty/ritmo/ui/components.kt
@@ -108,25 +108,11 @@ fun PlayerControls(
     }
 
     Column {
-        Row(modifier = Modifier.fillMaxWidth()) {
-/*            Button(
-                onClick = {
-                    onAction(PlayerControlAction.Back)
-                },
-                contentPadding = PaddingValues(1.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = Color.Transparent,
-                    contentColor = Color.Black
-                )
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.baseline_skip_previous_24),
-                    contentDescription = "Back",
-                    modifier = Modifier.size(60.dp)
-                )
-            }*/
-
-
+        Row(modifier = Modifier
+            .fillMaxWidth()
+            .clickable {
+                onShowDetailsAction()
+            }) {
             GlideImage(
                 model = musicHeader.imageUrl,
                 contentDescription = stringResource(id = R.string.description_for_image),

--- a/app/src/main/java/com/mccarty/ritmo/ui/navigation/AppNavigationActions.kt
+++ b/app/src/main/java/com/mccarty/ritmo/ui/navigation/AppNavigationActions.kt
@@ -13,7 +13,7 @@ class AppNavigationActions(private val navController: NavHostController) {
         }
     }
 
-    fun navigateToTrackDetails(trackIndex: Int? = 0) {
+    fun navigateToTrackDetails(trackIndex: Int) {
         navController.navigate(
             "${MainActivity.SONG_DETAILS_KEY}${trackIndex}"
         )

--- a/app/src/main/java/com/mccarty/ritmo/ui/navigation/AppNavigationActions.kt
+++ b/app/src/main/java/com/mccarty/ritmo/ui/navigation/AppNavigationActions.kt
@@ -13,7 +13,7 @@ class AppNavigationActions(private val navController: NavHostController) {
         }
     }
 
-    fun navigateToTrackDetails(trackIndex: Int) {
+    fun navigateToTrackDetails(trackIndex: Int? = 0) {
         navController.navigate(
             "${MainActivity.SONG_DETAILS_KEY}${trackIndex}"
         )

--- a/app/src/main/java/com/mccarty/ritmo/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/mccarty/ritmo/ui/screens/MainScreen.kt
@@ -65,6 +65,7 @@ fun MainScreen(
     onDetailsPlayPauseClicked: (TrackSelectAction) -> Unit,
     onNavigateToPlaylist: (String?, String?) -> Unit,
     onPlayerControlAction: (PlayerControlAction) -> Unit,
+    onNavigateToDetails: (Int?) -> Unit,
     mainItems: MainItemsState,
     trackUri: String?,
     playlistId: String?,
@@ -88,13 +89,13 @@ fun MainScreen(
             BottomAppBar(
                 containerColor = MaterialTheme.colorScheme.surfaceVariant,
                 contentColor = MaterialTheme.colorScheme.onBackground,
-                //modifier = Modifier.height(100.dp),
             ) {
                 PlayerControls(
                     mainViewModel = model,
                     onPlayerControlAction = { onPlayerControlAction(it) },
                     onShowDetailsAction = {
-
+                        playListItem?.tracks?.let { model.setPlayList(it) }
+                        onNavigateToDetails(playListItem?.index)
                     },
                 )
             }
@@ -172,7 +173,9 @@ fun MainScreen(
                                                 .fillMaxWidth()
                                                 .clickable(
                                                     onClick = {
-                                                        onDetailsPlayPauseClicked(
+                                                        onDetailsPlayPauseClicked(// TODO: this name is used in details
+                                                                                  // rename it to something that can be used
+                                                                                  // in details in in the list if items
                                                             TrackSelectAction.TrackSelect(
                                                                 index = itemIndex,
                                                                 duration = group.items[itemIndex].track?.duration_ms

--- a/app/src/main/java/com/mccarty/ritmo/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/mccarty/ritmo/ui/screens/MainScreen.kt
@@ -65,7 +65,7 @@ fun MainScreen(
     onDetailsPlayPauseClicked: (TrackSelectAction) -> Unit,
     onNavigateToPlaylist: (String?, String?) -> Unit,
     onPlayerControlAction: (PlayerControlAction) -> Unit,
-    onNavigateToDetails: (Int?) -> Unit,
+    onNavigateToDetails: (Int) -> Unit,
     mainItems: MainItemsState,
     trackUri: String?,
     playlistId: String?,
@@ -95,7 +95,7 @@ fun MainScreen(
                     onPlayerControlAction = { onPlayerControlAction(it) },
                     onShowDetailsAction = {
                         playListItem?.tracks?.let { model.setPlayList(it) }
-                        onNavigateToDetails(playListItem?.index)
+                        onNavigateToDetails(playListItem?.index ?: 0)
                     },
                 )
             }

--- a/app/src/main/java/com/mccarty/ritmo/ui/screens/Playlist.kt
+++ b/app/src/main/java/com/mccarty/ritmo/ui/screens/Playlist.kt
@@ -34,7 +34,7 @@ fun PlaylistScreen(
     onDetailsPlayPauseClicked: (TrackSelectAction) -> Unit,
     onPlaylistSelectAction: (PlaylistSelectAction) -> Unit,
     onPLayerControlAction: (PlayerControlAction) -> Unit,
-    onNavigateToDetails: (Int?) -> Unit,
+    onNavigateToDetails: (Int) -> Unit,
     onBack:() -> Unit,
 ) {
     val playLists by model.playLists.collectAsStateWithLifecycle()
@@ -58,7 +58,7 @@ fun PlaylistScreen(
                     onPlayerControlAction = { onPLayerControlAction(it) },
                     onShowDetailsAction = {
                         playListItem?.tracks?.let { model.setPlayList(it) }
-                        onNavigateToDetails(playListItem?.index)
+                        onNavigateToDetails(playListItem?.index ?: 0)
                     },
                 )
             }

--- a/app/src/main/java/com/mccarty/ritmo/ui/screens/Playlist.kt
+++ b/app/src/main/java/com/mccarty/ritmo/ui/screens/Playlist.kt
@@ -34,6 +34,7 @@ fun PlaylistScreen(
     onDetailsPlayPauseClicked: (TrackSelectAction) -> Unit,
     onPlaylistSelectAction: (PlaylistSelectAction) -> Unit,
     onPLayerControlAction: (PlayerControlAction) -> Unit,
+    onNavigateToDetails: (Int?) -> Unit,
     onBack:() -> Unit,
 ) {
     val playLists by model.playLists.collectAsStateWithLifecycle()
@@ -51,15 +52,13 @@ fun PlaylistScreen(
             BottomAppBar(
                 containerColor = MaterialTheme.colorScheme.surfaceVariant,
                 contentColor = MaterialTheme.colorScheme.onBackground,
-                //modifier = Modifier.height(100.dp),
             ) {
                 PlayerControls(
                     mainViewModel = model,
-                    onPlayerControlAction = {
-                        onPLayerControlAction(it)
-                    },
+                    onPlayerControlAction = { onPLayerControlAction(it) },
                     onShowDetailsAction = {
-                        // TODO: to implement
+                        playListItem?.tracks?.let { model.setPlayList(it) }
+                        onNavigateToDetails(playListItem?.index)
                     },
                 )
             }

--- a/app/src/main/java/com/mccarty/ritmo/ui/screens/Start.kt
+++ b/app/src/main/java/com/mccarty/ritmo/ui/screens/Start.kt
@@ -30,6 +30,7 @@ fun StartScreen(
     onPlaylistSelectAction: (PlaylistSelectAction) -> Unit,
     onNavigateToPlaylist: (String?, String?) -> Unit,
     onPlayerControlAction: (PlayerControlAction) -> Unit,
+    onNavigateToDetails: (Int?) -> Unit,
     mainItems: MainViewModel.MainItemsState,
     trackUri: String?,
     playlistId: String?,
@@ -60,6 +61,9 @@ fun StartScreen(
                 },
                 onPlayerControlAction = {
                     onPlayerControlAction(it)
+                },
+                onNavigateToDetails = {
+                    onNavigateToDetails(it)
                 }
             )
         }
@@ -107,7 +111,10 @@ fun StartScreen(
                     navController.popBackStack()
                 },
                 onPLayerControlAction = {
-                    // TODO: to implement
+                    onPlayerControlAction(it)
+                },
+                onNavigateToDetails = {
+                    onNavigateToDetails(it)
                 }
             )
         }

--- a/app/src/main/java/com/mccarty/ritmo/ui/screens/Start.kt
+++ b/app/src/main/java/com/mccarty/ritmo/ui/screens/Start.kt
@@ -30,7 +30,7 @@ fun StartScreen(
     onPlaylistSelectAction: (PlaylistSelectAction) -> Unit,
     onNavigateToPlaylist: (String?, String?) -> Unit,
     onPlayerControlAction: (PlayerControlAction) -> Unit,
-    onNavigateToDetails: (Int?) -> Unit,
+    onNavigateToDetails: (Int) -> Unit,
     mainItems: MainViewModel.MainItemsState,
     trackUri: String?,
     playlistId: String?,


### PR DESCRIPTION
Make icon and text clickable in the player control at bottom of main, and playlist screens. When clicked will go to details. At the moment if the app is entered and no playlist is in memory, the details screen will be blank. If there is a playlist in memory when entering the app, then we'll see details for the track and the user can swipe up or down to view the next track on details in that list.